### PR TITLE
Fix version of reverse_proxy_plug to 2.3.0

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -80,7 +80,7 @@ defmodule Ret.Mixfile do
       {:scrivener_ecto, "~> 2.0"},
       {:ua_parser, "~> 1.5"},
       {:download, git: "https://github.com/gfodor/download.git", branch: "reticulum/master"},
-      {:reverse_proxy_plug, "~> 2.1"},
+      {:reverse_proxy_plug, "2.3.0"},
       {:inet_cidr, "~> 1.0"},
       {:dns, "~> 2.2.0"},
       {:oauther, "~> 1.1"},


### PR DESCRIPTION
# Description

Fix reverse_proxy_plug version to 2.3.0 to prevent HTTP 500 errors during content import.

## reverse_proxy_plug >= 2.3.1
### 2.4.0

```bash
$ docker compose exec reticulum cat /ret/releases/1.0.0/ret.rel | grep reverse_proxy_plug
          {reverse_proxy_plug,"2.4.0",permanent},
```

<img width="1936" alt="image" src="https://github.com/taku1201/reticulum/assets/10263861/da117947-604a-43e7-8a53-e3f563be8d18">

### 2.3.1

```bash
$ docker compose exec reticulum cat /ret/releases/1.0.0/ret.rel | grep reverse_proxy_plug
          {reverse_proxy_plug,"2.3.1",permanent},
```

<img width="1936" alt="image" src="https://github.com/taku1201/reticulum/assets/10263861/4d6ca5f8-cb96-4ad7-b9f5-dfd52ae29431">

Sentry Event: https://taku-ito.sentry.io/share/issue/25e12e1405ac415d9c81ab38fb34d17e/

## reverse_proxy_plug <= 2.3.0

```bash
$ docker compose exec reticulum cat /ret/releases/1.0.0/ret.rel | grep reverse_proxy_plug
          {reverse_proxy_plug,"2.3.0",permanent},
```

<img width="1936" alt="image" src="https://github.com/taku1201/reticulum/assets/10263861/3bb15056-454b-4118-8558-8ae3f28e1302">


## Type of change

* Bug fix

